### PR TITLE
new dismissType - outsideTargetAndMessage added

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ maven:
 <dependency>
     <groupId>com.github.mreram</groupId>
     <artifactId>showcaseview</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 </dependency>
 ```
 gradle:
@@ -61,7 +61,7 @@ allprojects {
 ```	
 	Step 2. Add the dependency
 ```groovy	
-implementation 'com.github.mreram:showcaseview:1.3.0'
+implementation 'com.github.mreram:showcaseview:1.4.0'
 ```
 ## Change type face
 ```java

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ new GuideView.Builder(MainActivity.this)
 | outside | Dismissing with click on outside of MessageView |
 | anywhere | Dismissing with click on anywhere |
 | targetView | Dismissing with click on targetView(targetView is assigned with setTargetView method) |
+| outsideTargetAndMessage | Dismissing with click on outside of MessageView and target View |
 
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 30
     defaultConfig {
         applicationId "smartdevelop.ir.eram.showcaseview"
-        minSdkVersion 11
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="ir.smartdevelop.eram.showcaseview">
 
     <application
@@ -9,7 +11,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:windowSoftInputMode="stateHidden"  android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:windowSoftInputMode="stateHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/showcaseviewlib/build.gradle
+++ b/showcaseviewlib/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 11
         targetSdkVersion 30
-        versionCode 2
-        versionName "1.3.0"
+        versionCode 3
+        versionName "1.4.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/showcaseviewlib/src/main/java/smartdevelop/ir/eram/showcaseviewlib/GuideView.java
+++ b/showcaseviewlib/src/main/java/smartdevelop/ir/eram/showcaseviewlib/GuideView.java
@@ -360,6 +360,11 @@ public class GuideView extends FrameLayout {
                         dismiss();
                     }
                     break;
+
+                case outsideTargetAndMessage:
+                    if(!(targetRect.contains(x, y) || isViewContains(mMessageView, x, y))){
+                        dismiss();
+                    }
             }
             return true;
         }

--- a/showcaseviewlib/src/main/java/smartdevelop/ir/eram/showcaseviewlib/config/DismissType.java
+++ b/showcaseviewlib/src/main/java/smartdevelop/ir/eram/showcaseviewlib/config/DismissType.java
@@ -4,5 +4,5 @@ package smartdevelop.ir.eram.showcaseviewlib.config;
  * Created by Mohammad Reza Eram (https://github.com/mreram) on 27,November,2018
  */
 public enum DismissType {
-    outside, anywhere, targetView, selfView
+    outside, anywhere, targetView, selfView, outsideTargetAndMessage
 }


### PR DESCRIPTION
Solves #57 

`outsideTargetAndMessage` dismissType can be used for editTexts where we might want the guideView to remain while the user clicks on the editText and is typing. If the user clicks outside the target and message, then the guideView is dismissed which is natural.